### PR TITLE
Translator adapter and properties sheets work for diagrams that are not inside machines. Bugfix - Delete command did not work if selected element is not loaded

### DIFF
--- a/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.emf.diagrams.edit;singleton:=true
-Bundle-Version: 2.3.0.release
+Bundle-Version: 2.4.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: ac.soton.eventb.emf.diagrams.provider.DiagramsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractEditTablePropertySection.java
+++ b/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractEditTablePropertySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 University of Southampton and others.
+ * Copyright (c) 2014-2019 University of Southampton and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -245,12 +245,14 @@ public abstract class AbstractEditTablePropertySection extends AbstractIumlbProp
 	}
 
 	private class BLabelProvider extends LabelProvider{
+		
 		@Override
 		public String getText(final Object element){
 			if (element==null) return "<null>";
 			else if (element instanceof EventBNamed) return ((EventBNamed)element).getName();
 			return "<unknown element>";
 		}
+		
 		@Override
 		public org.eclipse.swt.graphics.Image getImage(final Object element){
 			if (element==null) return null;
@@ -272,10 +274,7 @@ public abstract class AbstractEditTablePropertySection extends AbstractIumlbProp
 		if (!(getFeature() instanceof EReference)) return null;
 		EReference feature = (EReference) getFeature();
 		EClass eClass = feature.getEReferenceType();
-		EventBObject container = owner.getContaining(CorePackage.Literals.PROJECT);
-		if (container == null){
-			container = owner.getContaining(CorePackage.Literals.EVENT_BNAMED_COMMENTED_COMPONENT_ELEMENT);
-		}
+		EventBObject container = getTranslationTarget();
 		if (container == null){ return ECollections.EMPTY_ELIST;}
 		EList<EObject> possibles = container.getAllContained(eClass, false);
 		possibles.removeAll(this.getElements());

--- a/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractIumlbPropertySection.java
+++ b/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractIumlbPropertySection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 University of Southampton.
+ * Copyright (c) 2014-2019 University of Southampton.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,13 +8,18 @@
 
 package ac.soton.eventb.emf.diagrams.sheet;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.gmf.runtime.diagram.ui.properties.sections.AbstractModelerPropertySection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbenchPart;
+import org.eventb.emf.core.Annotation;
+import org.eventb.emf.core.CorePackage;
 import org.eventb.emf.core.EventBElement;
+import org.eventb.emf.core.EventBObject;
 
 import ac.soton.eventb.emf.diagrams.util.custom.DiagramUtils;
 
@@ -26,6 +31,8 @@ import ac.soton.eventb.emf.diagrams.util.custom.DiagramUtils;
 public abstract class AbstractIumlbPropertySection extends
 		AbstractModelerPropertySection {
 
+	private static final String DIAGRAMS_TRANSLATION_TARGET = "ac.soton.diagrams.translationTarget";
+	
 	/**
 	 * The currently selected EventBElement or the first object in the selection
 	 * when multiple objects are selected.
@@ -72,6 +79,39 @@ public abstract class AbstractIumlbPropertySection extends
 		if (eObject instanceof EventBElement){
 			owner = (EventBElement)eObject;
 		}
+	}
+
+	/**
+	 * This gets the Event-B component to be used as the target for translation.
+	 * This component can be used to select Event-B elements to reference.
+	 * 
+	 * If the 'owner' is contained in a project, the project is returned
+	 * Otherwise, If the 'owner' is contained in a Event-B component, the component is returned
+	 * Otherwise, If the 'owner' has an "ac.soton.diagrams.translationTarget" annotation that references an EventBObject,
+	 * 	that referenced object is returned.
+	 * 
+	 * @return
+	 * @since 2.4
+	 */
+	protected EventBObject getTranslationTarget() {
+		EventBObject container = owner.getContaining(CorePackage.Literals.PROJECT);
+		if (container == null){
+			container = owner.getContaining(CorePackage.Literals.EVENT_BNAMED_COMMENTED_COMPONENT_ELEMENT);
+		}
+		if (container == null) {
+			EObject root = EcoreUtil.getRootContainer(owner);
+			if (root instanceof EventBElement) {
+				//EventBElement root = getRootElement(owner);
+				Annotation annotation = ((EventBElement)root).getAnnotation(DIAGRAMS_TRANSLATION_TARGET);
+				if (annotation!=null){
+					EList<EObject> references = annotation.getReferences();
+					if (!references.isEmpty() && references.get(0) instanceof EventBObject) {
+						container = (EventBObject) references.get(0);
+					}
+				}
+			}
+		}
+		return container;
 	}
 
 }

--- a/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractIumlbPropertySection.java
+++ b/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractIumlbPropertySection.java
@@ -8,18 +8,20 @@
 
 package ac.soton.eventb.emf.diagrams.sheet;
 
-import org.eclipse.emf.common.util.EList;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.gmf.runtime.diagram.ui.properties.sections.AbstractModelerPropertySection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eventb.emf.core.Annotation;
-import org.eventb.emf.core.CorePackage;
 import org.eventb.emf.core.EventBElement;
+import org.eventb.emf.core.EventBNamedCommentedComponentElement;
 import org.eventb.emf.core.EventBObject;
+import org.eventb.emf.core.context.Context;
+import org.eventb.emf.core.machine.Machine;
 
 import ac.soton.eventb.emf.diagrams.util.custom.DiagramUtils;
 
@@ -30,8 +32,6 @@ import ac.soton.eventb.emf.diagrams.util.custom.DiagramUtils;
  */
 public abstract class AbstractIumlbPropertySection extends
 		AbstractModelerPropertySection {
-
-	private static final String DIAGRAMS_TRANSLATION_TARGET = "ac.soton.diagrams.translationTarget";
 	
 	/**
 	 * The currently selected EventBElement or the first object in the selection
@@ -94,24 +94,41 @@ public abstract class AbstractIumlbPropertySection extends
 	 * @since 2.4
 	 */
 	protected EventBObject getTranslationTarget() {
-		EventBObject container = owner.getContaining(CorePackage.Literals.PROJECT);
-		if (container == null){
-			container = owner.getContaining(CorePackage.Literals.EVENT_BNAMED_COMMENTED_COMPONENT_ELEMENT);
-		}
-		if (container == null) {
-			EObject root = EcoreUtil.getRootContainer(owner);
-			if (root instanceof EventBElement) {
-				//EventBElement root = getRootElement(owner);
-				Annotation annotation = ((EventBElement)root).getAnnotation(DIAGRAMS_TRANSLATION_TARGET);
-				if (annotation!=null){
-					EList<EObject> references = annotation.getReferences();
-					if (!references.isEmpty() && references.get(0) instanceof EventBObject) {
-						container = (EventBObject) references.get(0);
-					}
-				}
-			}
-		}
-		return container;
+		return DiagramUtils.getTranslationTarget(owner);
 	}
 
+	/**
+	 * This gets all Event-B components that are in scope of the translation target
+	 * i.e. the target itself as well as the closure of all seen or extended contexts 
+	 * 
+	 * @since 2.4
+	 */
+	protected List<EventBNamedCommentedComponentElement> getComponentsInScope() {
+		return getComponentsInScope(getTranslationTarget());
+	}
+	
+	/**
+	 * This gets all Event-B components that are in scope of the one passed as input
+	 * i.e. the input itself as well as the closure of all seen or extended contexts 
+	 * 
+	 * @since 2.4
+	 */
+	protected List<EventBNamedCommentedComponentElement> getComponentsInScope(EventBObject eventBObject) {
+		List<EventBNamedCommentedComponentElement> list =  new ArrayList<EventBNamedCommentedComponentElement>() ;
+		if (eventBObject instanceof Machine){
+			Machine m = ((Machine)eventBObject);
+			list.add(m);
+			for (Context c : m.getSees()){
+				list.addAll(getComponentsInScope(c));
+			}			
+		}else if (eventBObject instanceof Context){
+			Context c = ((Context)eventBObject);
+			list.add(c);
+			for (Context x : c.getExtends()){
+				list.addAll(getComponentsInScope(x));
+			}
+		}
+		return list;
+	}
+	
 }

--- a/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/ElaboratesPropertySection.java
+++ b/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/ElaboratesPropertySection.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2013 University of Southampton.
+/**
+ * Copyright (c) 2013-2019 University of Southampton.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.views.properties.tabbed.ITabbedPropertyConstants;
 import org.eventb.emf.core.CorePackage;
+import org.eventb.emf.core.EventBObject;
 import org.eventb.emf.core.machine.Event;
 import org.eventb.emf.core.machine.Machine;
 import org.eventb.emf.core.machine.MachinePackage;
@@ -102,7 +103,8 @@ public class ElaboratesPropertySection extends AbstractEditTableWithReferencedOb
 	protected Object createNewElement(){
 		EObject newEvent = null;
 		// create and add new element
-		Machine machine = (Machine) owner.getContaining(MachinePackage.Literals.MACHINE);
+		EventBObject target = getTranslationTarget();
+		Machine machine = target instanceof Machine? (Machine) target : null;
 		NewEventDialog dialog = new NewEventDialog(getPart().getSite().getShell(), machine, null);
 		if (Dialog.OK == dialog.open()) {
 			newEvent = dialog.getEvent();

--- a/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/util/custom/DiagramUtils.java
+++ b/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/util/custom/DiagramUtils.java
@@ -1,8 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2014-2019 University of Southampton and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package ac.soton.eventb.emf.diagrams.util.custom;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -10,10 +16,8 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eventb.emf.core.Annotation;
 import org.eventb.emf.core.CorePackage;
-import org.eventb.emf.core.EventBCommented;
 import org.eventb.emf.core.EventBElement;
 import org.eventb.emf.core.EventBObject;
-import org.eventb.emf.persistence.EMFRodinDB;
 
 public class DiagramUtils {
 

--- a/ac.soton.eventb.emf.diagrams.feature/feature.properties
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010-2018 University of Southampton
+# Copyright (c) 2010-2019 University of Southampton
 # and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -25,7 +25,8 @@ It provides meta-classes, adapters and diagram provider for opening a diagram fr
 \n\
 Release history:\n\
 ------------------------------------------------------------------------------------------------------------\n\
-### 7.0.1 ### \n\
+### 7.1.0 ### \n\
+  edit (2.4.0) 		- properties sheets should work for diagrams that are not in a machine\n\
   navigator (3.1.1) - fix - delete command did not work if element not loaded\n\
 ### 7.0.0 ### \n\
   diagrams (4.1.0) 	- upgrade execution environment to Java 1.8\n\
@@ -186,7 +187,7 @@ Release history:\n\
  - Initial release\n\
 
 # "copyright" property - copyright of the feature
-featureCopyright=Copyright (c) 2011-2018 University of Southampton. All rights reserved.
+featureCopyright=Copyright (c) 2011-2019 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - label for the update site
 updateSiteName=Main Rodin update site

--- a/ac.soton.eventb.emf.diagrams.feature/feature.properties
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.properties
@@ -25,6 +25,8 @@ It provides meta-classes, adapters and diagram provider for opening a diagram fr
 \n\
 Release history:\n\
 ------------------------------------------------------------------------------------------------------------\n\
+### 7.0.1 ### \n\
+  navigator (3.1.1) - fix - delete command did not work if element not loaded\n\
 ### 7.0.0 ### \n\
   diagrams (4.1.0) 	- upgrade execution environment to Java 1.8\n\
   branding (1.0.0)  - initial branding plugin\n\

--- a/ac.soton.eventb.emf.diagrams.feature/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.diagrams.feature"
       label="%featureName"
-      version="7.0.0.release"
+      version="7.0.1.qualifier"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.emf.diagrams.branding"
       license-feature="org.rodinp.license"

--- a/ac.soton.eventb.emf.diagrams.feature/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.diagrams.feature"
       label="%featureName"
-      version="7.0.1.qualifier"
+      version="7.1.0.qualifier"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.emf.diagrams.branding"
       license-feature="org.rodinp.license"

--- a/ac.soton.eventb.emf.diagrams.generator/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams.generator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.emf.diagrams.generator;singleton:=true
-Bundle-Version: 4.0.0.release
+Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: ac.soton.eventb.emf.diagrams.generator.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",

--- a/ac.soton.eventb.emf.diagrams.generator/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams.generator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.emf.diagrams.generator;singleton:=true
-Bundle-Version: 4.1.0.qualifier
+Bundle-Version: 4.0.1.qualifier
 Bundle-Activator: ac.soton.eventb.emf.diagrams.generator.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",
  ac.soton.eventb.emf.core.extension;bundle-version="[5.0.0,6.0.0)",
  ac.soton.emf.translator;bundle-version="[3.0.0,4.0.0)",
  ac.soton.emf.translator.eventb;bundle-version="[0.0.1,1.0.0)",
- org.eventb.core;bundle-version="[3.3.0,4.0.0)"
+ org.eventb.core;bundle-version="[3.3.0,4.0.0)",
+ ac.soton.eventb.emf.diagrams.edit;bundle-version="[2.4.0,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: ac.soton.eventb.emf.diagrams.generator,

--- a/ac.soton.eventb.emf.diagrams.generator/plugin.xml
+++ b/ac.soton.eventb.emf.diagrams.generator/plugin.xml
@@ -40,9 +40,20 @@
                      variable="selection">
                   <iterate
                         ifEmpty="false">
-                     <instanceof
-                           value="org.eventb.core.IMachineRoot">
-                     </instanceof>
+                     <or>
+	                   <instanceof
+	                         value="org.eventb.core.IMachineRoot">
+	                   </instanceof>
+	                   <instanceof
+	                         value="org.eventb.core.IContextRoot">
+	                   </instanceof>
+		               <adapt
+		                     type="org.eclipse.emf.ecore.EObject">
+		                  <instanceof
+		                        value="ac.soton.eventb.emf.diagrams.Diagram">
+		                  </instanceof>
+		               </adapt>
+                     </or>
                   </iterate>
                </with>
             </visibleWhen>

--- a/ac.soton.eventb.emf.diagrams.generator/src/ac/soton/eventb/emf/diagrams/generator/adapter/IUMLBTranslatorAdapter.java
+++ b/ac.soton.eventb.emf.diagrams.generator/src/ac/soton/eventb/emf/diagrams/generator/adapter/IUMLBTranslatorAdapter.java
@@ -15,13 +15,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
-import org.eventb.emf.core.Annotation;
-import org.eventb.emf.core.CorePackage;
 import org.eventb.emf.core.EventBElement;
 import org.eventb.emf.core.EventBNamedCommentedComponentElement;
 import org.eventb.emf.core.EventBObject;
@@ -31,6 +28,7 @@ import org.eventb.emf.core.machine.Machine;
 import ac.soton.emf.translator.configuration.IAdapter;
 import ac.soton.emf.translator.eventb.adapter.EventBTranslatorAdapter;
 import ac.soton.emf.translator.eventb.utils.Utils;
+import ac.soton.eventb.emf.diagrams.util.custom.DiagramUtils;
 
 
 /**
@@ -88,29 +86,15 @@ public class IUMLBTranslatorAdapter extends EventBTranslatorAdapter implements I
 		}
 		return list;
 	}
-
-	private static final String DIAGRAMS_TRANSLATION_TARGET = "ac.soton.diagrams.translationTarget";
 	
 	/* (non-Javadoc)
 	 * @see ac.soton.emf.translator.eventb.adapter.EventBTranslatorAdapter#getTargetComponent(java.lang.Object)
 	 */
 	@Override
 	public Object getTargetComponent(Object sourceElement) {
-		EventBNamedCommentedComponentElement container = null;
-		if (sourceElement instanceof EObject) {
-		EObject root = EcoreUtil.getRootContainer((EObject) sourceElement);
-		if (root instanceof EventBObject) {
-			container = (EventBNamedCommentedComponentElement) ((EventBObject)root).getContaining(CorePackage.Literals.EVENT_BNAMED_COMMENTED_COMPONENT_ELEMENT);
-			if (container==null){
-				Annotation annotation = ((EventBObject)root).getAnnotation(DIAGRAMS_TRANSLATION_TARGET);
-				if (annotation!=null){
-					EList<EObject> references = annotation.getReferences();
-					if (!references.isEmpty() && references.get(0) instanceof EventBObject) {
-						container = (EventBNamedCommentedComponentElement)references.get(0);
-					}
-				}
-			}
-		}
+		Object container = null;
+		if (sourceElement instanceof EventBObject) {
+			container = DiagramUtils.getTranslationTarget((EventBObject)sourceElement);
 		}
 		return container == null? 
 			super.getTargetComponent(sourceElement) :

--- a/ac.soton.eventb.emf.diagrams.generator/src/ac/soton/eventb/emf/diagrams/generator/handlers/IUMLBTranslateAllHandler.java
+++ b/ac.soton.eventb.emf.diagrams.generator/src/ac/soton/eventb/emf/diagrams/generator/handlers/IUMLBTranslateAllHandler.java
@@ -50,7 +50,7 @@ import ac.soton.eventb.emf.diagrams.generator.commands.TranslateAllCommand;
  */
 public class IUMLBTranslateAllHandler extends AbstractHandler {
 
-	String report = null;
+	String report = "";
 	IStatus status = null;
 	
 	/* (non-Javadoc)
@@ -87,7 +87,7 @@ public class IUMLBTranslateAllHandler extends AbstractHandler {
 							TranslateAllCommand translateAllCmd = new TranslateAllCommand(editingDomain, (EventBElement) root);
 							if (translateAllCmd.canExecute()){
 								status = translateAllCmd.execute(null, null);
-								report = report+status.getMessage();
+								report = status.getMessage();
 								// save all resources that have been modified
 								SaveResourcesCommand saveCommand = new SaveResourcesCommand(editingDomain);
 								if (saveCommand.canExecute()){

--- a/ac.soton.eventb.emf.diagrams.navigator/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.emf.diagrams.navigator;singleton:=true
-Bundle-Version: 3.1.0.release
+Bundle-Version: 3.1.1.qualifier
 Bundle-Activator: ac.soton.eventb.emf.diagrams.navigator.DiagramsNavigatorExtensionPlugin
 Require-Bundle: org.eclipse.ui.navigator;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.7.0,4.0.0)",

--- a/ac.soton.eventb.emf.diagrams.sdk/feature.properties
+++ b/ac.soton.eventb.emf.diagrams.sdk/feature.properties
@@ -27,6 +27,9 @@ It provides meta-classes, adapters and diagram provider for opening a diagram fr
 \n\
 Release history:\n\
 ------------------------------------------------------------------------------------------------------------\n\
+### 7.0.1 ### \n\
+- Event-B GMF Support for Diagrams Feature (7.0.1)\n\
+- Event-B GMF Support for Diagrams Source Feature (7.0.1): Generated\n\
 ### 7.0.0 ### \n\
 - Event-B GMF Support for Diagrams Feature (7.0.0)\n\
 - Event-B GMF Support for Diagrams Source Feature (7.0.0): Generated\n\

--- a/ac.soton.eventb.emf.diagrams.sdk/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.diagrams.sdk"
       label="%featureName"
-      version="7.0.0.release"
+      version="7.0.1.qualifier"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.emf.diagrams.branding"
       license-feature="org.rodinp.license"

--- a/ac.soton.eventb.emf.diagrams/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.emf.diagrams;singleton:=true
-Bundle-Version: 4.1.0.release
+Bundle-Version: 4.1.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Delete (in navigator context menu) did not work for diagrams until their contents have been viewed in the navigator. This is because the diagram root remains a proxy and the model has not been loaded into EMF. This mod loads the EMF model if it has not already been loaded, so that the diagram can be deleted.