### PR TITLE
fix UML-B refinement

### DIFF
--- a/ac.soton.eventb.emf.diagrams.navigator/plugin.xml
+++ b/ac.soton.eventb.emf.diagrams.navigator/plugin.xml
@@ -62,10 +62,6 @@
             content-type="org.eclipse.emf.compare.content.type"
             file-extensions="umlb">
       </file-association>
-      <file-association
-            content-type="ac.soton.eventb.emf.diagrams.navigator.file-association2"
-            file-extensions="umlb">
-      </file-association>
    </extension>
    
    <extension
@@ -129,11 +125,6 @@
             name="Archive Project">
       </command>
       <command
-            description="create a new UML-B model"
-            id="ac.soton.eventb.emf.diagrams.navigator.commands.newUMLB"
-            name="New UML-B">
-      </command>
-      <command
             categoryId="ac.soton.eventb.emf.diagrams.iUMLB"
             defaultHandler="ac.soton.eventb.emf.diagrams.navigator.handler.DeleteDiagramElementHandler"
             description="Delete the selected iUML-B diagram"
@@ -174,12 +165,6 @@
                   </iterate>
                </with>
             </visibleWhen>
-         </command>
-         
-         <command
-               commandId="ac.soton.eventb.emf.diagrams.navigator.commands.newUMLB"
-               icon="icons/UMLB.gif"
-               tooltip="Create a new container for UML-B diagrams">
          </command>
             
          <command
@@ -299,10 +284,11 @@
             finalPerspective="org.eventb.ui.perspective.eventb"
             icon="icons/UMLB.gif"
             id="ac.soton.eventb.emf.diagrams.NewUMLB"
-            name="New UML-B wizard"
+            name="UML-B"
             preferredPerspectives="org.eventb.ui.perspective.eventb,org.eventb.ui.perspective.proving"
             project="false"/>
    </extension>
+   
       <extension
             point="ac.soton.eventb.emf.core.extension.navigator.elementRefinement">
          <refinementDefinition

--- a/ac.soton.eventb.emf.diagrams.navigator/src/ac/soton/eventb/emf/diagrams/navigator/handler/RefineDiagramElementHandler.java
+++ b/ac.soton.eventb.emf.diagrams.navigator/src/ac/soton/eventb/emf/diagrams/navigator/handler/RefineDiagramElementHandler.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2020-2020 University of Southampton.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
 package ac.soton.eventb.emf.diagrams.navigator.handler;
 
 import java.util.Map;
@@ -13,9 +21,11 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.jface.dialogs.IInputValidator;
+import org.eclipse.jface.dialogs.InputDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eventb.emf.core.EventBElement;
 import org.eventb.emf.persistence.EMFRodinDB;
@@ -26,64 +36,82 @@ import ac.soton.eventb.emf.core.extension.navigator.refiner.ElementRefinerRegist
 import ac.soton.eventb.emf.diagrams.navigator.DiagramsNavigatorExtensionPlugin;
 
 /**
+ * This creates a refinement copy of the selected diagram model
+ * 
+ * @author cfs
  * @since 3.2
  */
 public class RefineDiagramElementHandler extends AbstractHandler implements IHandler {
 
 	private final IProgressMonitor monitor = new NullProgressMonitor();
 	
+	/**
+	 * a name validator for the input dialog that gets a new name
+	 */
+	static final IInputValidator nameValidator = new IInputValidator(){
+		@Override
+		public String isValid(String name) {
+			if (name.trim().isEmpty())
+				return "";
+			return null;
+		}
+	};
+	
+	/* (non-Javadoc)
+	 * @see org.eclipse.core.commands.IHandler#execute(org.eclipse.core.commands.ExecutionEvent)
+	 */
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		ISelection selection = HandlerUtil.getCurrentSelectionChecked(event);
+		
 		if (selection instanceof IStructuredSelection) {
 			Object element = ((IStructuredSelection) selection).getFirstElement();
-			final EventBElement eventBElement = getDiagramElement(element);
-			//final Resource resource = getRefinedResource(eventBElement.eResource(), eventBElement.eResource().getURI().lastSegment()+"0");
-			URI concreteResourceUri = getRefinedResource(eventBElement.eResource(), eventBElement.eResource().getURI().lastSegment()+"0");
-			TransactionalEditingDomain editingDomain = TransactionalEditingDomain.Factory.INSTANCE.createEditingDomain(); //TransactionUtil.getEditingDomain(resource);
-			//final Resource resource = editingDomain.getResourceSet().createResource(uri);
-			final Resource resource = editingDomain.createResource(concreteResourceUri.toString());
-//			try {
-//				resource.save(Collections.emptyMap());
-//			} catch (IOException e) {
-//				// TODO Auto-generated catch block
-//				e.printStackTrace();
-//			}
-			//editingDomain.isReadOnly(resource)
+			
+			//load the EventBElement corresponding to the element selected in the navigator
+			final EventBElement eventBElement = loadEventBElement(element);
+			
+			//Ask user for a new name
+			InputDialog dialog = new InputDialog(
+					Display.getCurrent().getActiveShell(), 
+					"Refined UML-B Diagram Model", 
+					" name: ",
+					eventBElement.eResource().getURI().trimFileExtension().lastSegment()+"0",
+					nameValidator);
+			if (dialog.open() == InputDialog.CANCEL) return null;
+			
+			//work out the URI of the refined resource using the new name
+			URI concreteResourceUri = getRefinedResourceURI(eventBElement.eResource(), dialog.getValue().trim());
+			
+			//get a resource for the refined element (it will be created if it does not exist already)
+			EMFRodinDB emfRodinDB = new EMFRodinDB();
+			final Resource targetResource = emfRodinDB.getResource(concreteResourceUri);
 
+			//find a suitable refiner
 			AbstractElementRefiner refiner = ElementRefinerRegistry.getRegistry().getRefiner(eventBElement);
 			if (refiner!=null) {
+				
+				//make the refined element
 				Map<EObject,EObject> copier = refiner.refine(eventBElement, concreteResourceUri);
-						//cloneAsAlternativeRefinement(eventBElement, null, preComponentRes.getURI());
-				EObject refinedElement = copier.get(eventBElement);
+				EventBElement refinedElement = (EventBElement) copier.get(eventBElement);
 
-//			//resource.getContents().add(refinedElement);
-//			if (editingDomain != null) {
-//				//editingDomain.createCommand(commandClass, commandParameter)
-//				// command to delete the diagram element from the model
-//				Command refineDiagramCommand =  new RecordingCommand(editingDomain, "Refine Diagram Command") {
-//					protected void doExecute() {
-						resource.eSetDeliver(false);
-						resource.getContents().add(0,refinedElement);
-						resource.eSetDeliver(true);
-//					}
-//				};
-//				if (refineDiagramCommand.canExecute()){
-//					//refine the diagram model element
-//					refineDiagramCommand.execute();
-					resource.setModified(true); 
-					// save all resources that have been modified
-					SaveResourcesCommand saveCommand = new SaveResourcesCommand(editingDomain);
-					if (saveCommand.canExecute()){
-							saveCommand.execute(monitor, null);
-					}
-				}else{
-					DiagramsNavigatorExtensionPlugin.logError("Failed to refine diagram - aborted refine of : "+eventBElement);
+				//put the refined element in the resource
+				emfRodinDB.setContent(targetResource, refinedElement);
+			
+				//make sure the resource is marked as modified
+				targetResource.setModified(true); 
+				
+				// save all resources that have been modified
+				SaveResourcesCommand saveCommand = new SaveResourcesCommand(emfRodinDB.getEditingDomain());
+				if (saveCommand.canExecute()){
+						saveCommand.execute(monitor, null);
 				}
+			}else{
+				DiagramsNavigatorExtensionPlugin.logError("Failed to refine diagram - aborted refine of : "+eventBElement);
 			}
-//		}
+		}
 		return null;
 	}
+
 
 	/**
 	 * if element is adaptable, adapts the element to an EObject and then if necessary loads it
@@ -91,24 +119,30 @@ public class RefineDiagramElementHandler extends AbstractHandler implements IHan
 	 * @param element
 	 * @return EventBElement (loaded)
 	 */
-		private EventBElement getDiagramElement(Object element) {
-			if (element instanceof IAdaptable) {
-				EObject eobject = (EObject) ((IAdaptable) element).getAdapter(EObject.class);
-				if (eobject.eIsProxy()) {
-					EMFRodinDB emfrdb = new EMFRodinDB();
-					eobject = emfrdb.loadElement(((InternalEObject)eobject).eProxyURI());
-				}
-				if (eobject instanceof EventBElement) {
-					return (EventBElement)eobject;
-				}
+	private EventBElement loadEventBElement(Object element) {
+		if (element instanceof IAdaptable) {
+			EObject eobject = (EObject) ((IAdaptable) element).getAdapter(EObject.class);
+			if (eobject.eIsProxy()) {
+				EMFRodinDB emfrdb = new EMFRodinDB();
+				eobject = emfrdb.loadElement(((InternalEObject)eobject).eProxyURI());
 			}
-			return null;
+			if (eobject instanceof EventBElement) {
+				return (EventBElement)eobject;
+			}
 		}
-		
-		private URI getRefinedResource(Resource resource, String newName) {
-			URI newUri = resource.getURI();
-			String fileExtension = newUri.fileExtension();
-			newUri = newUri.trimSegments(1).appendSegment(newName).appendFileExtension(fileExtension);
-			return newUri; //resource.getResourceSet().createResource(newUri);
-		}
+		return null;
+	}
+	
+	/**
+	 * returns the URI for a new resource, based on the given resource but with the filename changed to newName
+	 * @param resource
+	 * @param newName
+	 * @return
+	 */
+	private URI getRefinedResourceURI(Resource resource, String newName) {
+		URI newUri = resource.getURI();
+		String fileExtension = newUri.fileExtension();
+		newUri = newUri.trimSegments(1).appendSegment(newName).appendFileExtension(fileExtension);
+		return newUri; 
+	}
 }

--- a/ac.soton.eventb.emf.diagrams.navigator/src/ac/soton/eventb/emf/diagrams/navigator/refiner/UMLBElementRefiner.java
+++ b/ac.soton.eventb.emf.diagrams.navigator/src/ac/soton/eventb/emf/diagrams/navigator/refiner/UMLBElementRefiner.java
@@ -10,10 +10,13 @@ package ac.soton.eventb.emf.diagrams.navigator.refiner;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
 import org.eventb.emf.core.EventBNamedCommentedComponentElement;
 
@@ -29,13 +32,7 @@ import ac.soton.eventb.emf.diagrams.UMLB;
  * @author cfsnook
  *
  */
-
 public class UMLBElementRefiner extends AbstractElementRefiner {
-
-//	public UMLBElementRefiner() {
-//		// TODO Auto-generated constructor stub
-//	}
-
 
 	@Override
 	protected void populateFilterByTypeList(List<EClass> filterList) {
@@ -54,36 +51,74 @@ public class UMLBElementRefiner extends AbstractElementRefiner {
 
 	/**
 	 * Overridden to change the name of the UMLB
+	 * and to fix the references which, in our case, are messed up by AbstractElementRefiner
 	 * 
 	 * (non-Javadoc)
 	 * @see ac.soton.eventb.emf.core.extension.navigator.refiner.AbstractElementRefiner#copyReferences(org.eclipse.emf.ecore.EObject, org.eclipse.emf.ecore.util.EcoreUtil.Copier, org.eclipse.emf.common.util.URI, org.eclipse.emf.common.util.URI, org.eventb.emf.core.EventBNamedCommentedComponentElement, java.lang.String, ac.soton.eventb.emf.core.extension.navigator.refiner.AbstractElementRefiner.Mode)
 	 */
 	@Override
-	protected void copyReferences(EObject concreteElement, Copier copier, URI abstractUri, URI concreteResourceURI, String concreteComponentName, Mode mode) {
+	protected void copyReferences(
+			EObject concreteElement, 
+			Copier copier, 
+			URI abstractUri, 
+			URI concreteResourceURI, 
+			EventBNamedCommentedComponentElement concreteComponent, 
+			String concreteComponentName, 
+			Mode mode) {
 		
 		if (concreteElement instanceof UMLB) {
 			((UMLB)concreteElement).setName(concreteComponentName==null? concreteResourceURI.trimFileExtension().lastSegment() : concreteComponentName);
 		}
 		
-		super.copyReferences(concreteElement, copier, abstractUri, concreteResourceURI, concreteComponentName, mode);
+		super.copyReferences(concreteElement, copier, abstractUri, concreteResourceURI, concreteComponent, concreteComponentName, mode);
+		
+		//the AbstractElementRefiner gets the fragment part of the reference URI wrong because 
+		// it assumes the refined element will be added to a Machine or Context
+		// therefore we find each such reference and fix it
+		String abstractFileName = abstractUri.trimFileExtension().lastSegment();
+		if (concreteElement instanceof UMLB) {
+			TreeIterator<EObject> contents = ((UMLB)concreteElement).eAllContents();
+			while (contents.hasNext()) {
+				EObject element = contents.next();
+				for (EReference feature : element.eClass().getEAllReferences()) {
+					if (!feature.isContainment()) {
+						if (feature.isMany()) {
+							@SuppressWarnings("unchecked")
+							EList<InternalEObject> refList = (EList<InternalEObject>) element.eGet(feature, false);
+							for (InternalEObject refValue : refList) {
+								fix_fragment(concreteComponentName, abstractFileName, refValue);								
+							}
+						}else {
+							InternalEObject refValue = (InternalEObject) element.eGet(feature, false);
+							fix_fragment(concreteComponentName, abstractFileName, refValue);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param concreteComponentName
+	 * @param abstractFileName
+	 * @param refValue
+	 */
+	private void fix_fragment(String concreteComponentName, String abstractFileName, InternalEObject refValue) {
+		if (refValue!=null && refValue.eIsProxy()) {
+			URI uri = refValue.eProxyURI();
+			String fileName = uri.trimFileExtension().lastSegment();
+			if (fileName.equals(concreteComponentName)) {
+				String fragment = uri.fragment();
+				int idStart = fragment.lastIndexOf("::")+2;
+				String id = fragment.substring(idStart);
+				if (id.startsWith(concreteComponentName+"."+abstractFileName+".")) {
+					id = id.replace(concreteComponentName+"."+abstractFileName, concreteComponentName);
+					fragment = fragment.substring(0, idStart)+id;
+					uri = uri.trimFragment().appendFragment(fragment);
+					refValue.eSetProxyURI(uri);
+				}
+			}		
+		}
 	}
 	
-//	/* (non-Javadoc)
-//	 * @see ac.soton.eventb.emf.core.extension.navigator.refiner.AbstractElementRefiner#getEquivalentObject(org.eclipse.emf.ecore.EObject, org.eclipse.emf.ecore.EObject)
-//	 */
-//	@Override
-//	public EventBObject getEquivalentObject(EObject concreteParent, EObject abstractObject) {
-//		// TODO Auto-generated method stub
-//		return super.getEquivalentObject(concreteParent, abstractObject);
-//	}
-//
-//	/* (non-Javadoc)
-//	 * @see ac.soton.eventb.emf.core.extension.navigator.refiner.AbstractElementRefiner#getEquivalentObject(org.eclipse.emf.ecore.EObject, org.eclipse.emf.ecore.EStructuralFeature, org.eclipse.emf.ecore.EObject)
-//	 */
-//	@Override
-//	public EventBObject getEquivalentObject(EObject concreteParent, EStructuralFeature feature, EObject abstractObject) {
-//		// TODO Auto-generated method stub
-//		return super.getEquivalentObject(concreteParent, feature, abstractObject);
-//	}
-
 }


### PR DESCRIPTION
The refinement of models in UML-B containers did not work because the extensions feature assumes models are in Machines or Contexts. To avoid changing the extensions feature  (which could risk breaking other use cases) , for now I have 'post' fixed the references using string manipulations in the UML-B refiner.  Also some tidy up of the handler and remove unused extensions.