### PR TITLE
bug fix  and avoid having to add update sites

### DIFF
--- a/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.emf.diagrams.edit;singleton:=true
-Bundle-Version: 3.0.1.qualifier
+Bundle-Version: 3.0.1.release
 Bundle-ClassPath: .
 Bundle-Activator: ac.soton.eventb.emf.diagrams.provider.DiagramsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: ac.soton.eventb.emf.diagrams.provider,
  ac.soton.eventb.emf.diagrams.sheet,
  ac.soton.eventb.emf.diagrams.util.custom
-Require-Bundle: org.eclipse.emf.ecore.edit;bundle-version="[2.13.0,3.0.0)",
+Require-Bundle: org.eclipse.emf.ecore.edit;bundle-version="[2.9.0,3.0.0)",
  org.eclipse.gmf.runtime.diagram.ui.properties;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.gmf.runtime.diagram.ui.resources.editor;bundle-version="[1.0.0,2.0.0)",
  org.rodinp.keyboard.ui;bundle-version="[2.0.0,3.0.0)",

--- a/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.emf.diagrams.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.emf.diagrams.edit;singleton:=true
-Bundle-Version: 3.0.0.release
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: ac.soton.eventb.emf.diagrams.provider.DiagramsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractEditTableWithReferencedObjectCreationDeletionPropertySection.java
+++ b/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/sheet/AbstractEditTableWithReferencedObjectCreationDeletionPropertySection.java
@@ -10,7 +10,6 @@ package ac.soton.eventb.emf.diagrams.sheet;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.edit.command.RemoveCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor;
@@ -90,7 +89,7 @@ public abstract class AbstractEditTableWithReferencedObjectCreationDeletionPrope
 				removeObject(objectToBeRemoved);
 				//delete the element
 				EditingDomain editingDomain = ((DiagramEditor) getPart()).getEditingDomain();
-				EObject container = EcoreUtil.getRootContainer(eObject);
+				EObject container = getTranslationTarget();
 				editingDomain.getCommandStack().execute(
 						RemoveCommand.create(editingDomain, container, null, objectToBeRemoved));
 			}

--- a/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/util/custom/DiagramUtils.java
+++ b/ac.soton.eventb.emf.diagrams.edit/src/ac/soton/eventb/emf/diagrams/util/custom/DiagramUtils.java
@@ -87,6 +87,7 @@ public class DiagramUtils {
 	 * 
 	 * If the 'owner' is contained in a project, the project is returned
 	 * Otherwise, If the 'owner' is contained in a Event-B component, the component is returned
+	 * Otherwise, If the 'owner' is contained in an UML-B the elaborated component (of the UML-B) is return
 	 * Otherwise, If the 'owner' has an "ac.soton.diagrams.translationTarget" annotation that references an EventBObject,
 	 * 	that referenced object is returned.
 	 * 

--- a/ac.soton.eventb.emf.diagrams.feature/feature.properties
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.properties
@@ -28,6 +28,8 @@ This is just a basis; you should also install the specific diagram types you nee
 \n\
 Release history:\n\
 ------------------------------------------------------------------------------------------------------------\n\
+### 8.0.1 ### \n\
+  edit (3.0.1) 		- fix problem with delete elaborated element\n\
 ### 8.0.0 ### \n\
   diagrams (5.0.0)	- new UMLB element added as container for diagrams\n\
   edit (3.0.0) 		- removed copyright fields\n\

--- a/ac.soton.eventb.emf.diagrams.feature/feature.properties
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.properties
@@ -30,6 +30,7 @@ Release history:\n\
 ------------------------------------------------------------------------------------------------------------\n\
 ### 8.0.1 ### \n\
   edit (3.0.1) 		- fix problem with delete elaborated element\n\
+  					- relax lower dependency bound on org.eclipse.emf.ecore.edit\n\
 ### 8.0.0 ### \n\
   diagrams (5.0.0)	- new UMLB element added as container for diagrams\n\
   edit (3.0.0) 		- removed copyright fields\n\

--- a/ac.soton.eventb.emf.diagrams.feature/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.diagrams.feature"
       label="%featureName"
-      version="8.0.1.qualifier"
+      version="8.0.1.release"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.emf.diagrams.branding"
       license-feature="org.rodinp.licence"

--- a/ac.soton.eventb.emf.diagrams.feature/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.diagrams.feature"
       label="%featureName"
-      version="8.0.0.release"
+      version="8.0.1.qualifier"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.emf.diagrams.branding"
       license-feature="org.rodinp.licence"

--- a/ac.soton.eventb.emf.diagrams.feature/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.feature/feature.xml
@@ -33,6 +33,7 @@
       <import plugin="ac.soton.eventb.emf.diagrams.generator" version="4.0.0" match="compatible"/>
       <import plugin="org.eclipse.gmf.runtime.diagram.ui" version="1.8.0" match="compatible"/>
       <import plugin="ac.soton.eventb.emf.diagrams" version="5.0.0" match="compatible"/>
+      <import plugin="ac.soton.eventb.emf.core.extension.navigator" version="5.1.0" match="compatible"/>
       <import plugin="ac.soton.eventb.emf.diagrams.edit" version="3.0.0" match="compatible"/>
       <import plugin="org.eclipse.gmf.runtime.diagram.ui.resources.editor" version="1.4.0" match="compatible"/>
       <import plugin="org.eclipse.gmf.runtime.diagram.ui" version="1.5.0" match="compatible"/>
@@ -41,7 +42,6 @@
       <import plugin="ac.soton.emf.translator" version="3.0.0" match="compatible"/>
       <import plugin="ac.soton.emf.translator.eventb" version="0.0.1" match="compatible"/>
       <import plugin="org.eventb.core" version="3.3.0" match="compatible"/>
-      <import plugin="org.eclipse.emf.ecore.edit" version="2.13.0" match="compatible"/>
       <import plugin="org.eclipse.gmf.runtime.diagram.ui.properties" version="1.0.0" match="compatible"/>
       <import plugin="org.eclipse.gmf.runtime.diagram.ui.resources.editor" version="1.0.0" match="compatible"/>
       <import plugin="org.rodinp.keyboard.ui" version="2.0.0" match="compatible"/>
@@ -50,7 +50,7 @@
       <import plugin="fr.systerel.explorer" version="2.0.0" match="compatible"/>
       <import plugin="ac.soton.eventb.emf.core.extension.navigator" version="5.0.0" match="compatible"/>
       <import plugin="ac.soton.eventb.emf.diagrams.navigator" version="3.0.0" match="compatible"/>
-      <import plugin="ac.soton.eventb.emf.core.extension.navigator" version="5.1.0" match="compatible"/>
+      <import plugin="org.eclipse.emf.ecore.edit" version="2.9.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/ac.soton.eventb.emf.diagrams.sdk/feature.properties
+++ b/ac.soton.eventb.emf.diagrams.sdk/feature.properties
@@ -25,6 +25,9 @@ Event-B EMF Diagrams feature. \n\
 \n\
 Release history:\n\
 ------------------------------------------------------------------------------------------------------------\n\
+### 8.0.1 ### \n\
+- Event-B GMF Support for Diagrams Feature (8.0.1)\n\
+- Event-B GMF Support for Diagrams Source Feature (8.0.1): Generated\n\
 ### 8.0.0 ### \n\
 - Event-B GMF Support for Diagrams Feature (8.0.0)\n\
 - Event-B GMF Support for Diagrams Source Feature (8.0.0): Generated\n\

--- a/ac.soton.eventb.emf.diagrams.sdk/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.diagrams.sdk"
       label="%featureName"
-      version="8.0.0.release"
+      version="8.0.1.qualifier"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.emf.diagrams.branding"
       license-feature="org.rodinp.licence"

--- a/ac.soton.eventb.emf.diagrams.sdk/feature.xml
+++ b/ac.soton.eventb.emf.diagrams.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.eventb.emf.diagrams.sdk"
       label="%featureName"
-      version="8.0.1.qualifier"
+      version="8.0.1.release"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.emf.diagrams.branding"
       license-feature="org.rodinp.licence"


### PR DESCRIPTION
There was a bug when deleting elaborated elements (e.g. event elaboration)
Also the lower bound for a dependency was unnecessarily high which meant that a later EMF update site had to be added to install.